### PR TITLE
Fix quotation marks in postCreateScript.sh

### DIFF
--- a/.devcontainer/postCreateScript.sh
+++ b/.devcontainer/postCreateScript.sh
@@ -47,7 +47,7 @@ readonly ALIAS_SRC_URL="https://raw.githubusercontent.com/gvatsal60/Linux-Aliase
 # Install Linux aliases from external script using curl and execute immediately
 # Note: Make sure to review scripts fetched from external sources for security reasons
 if command -v curl >/dev/null 2>&1; then
-    curl -fsSL ${ALIAS_SRC_URL} | sh
+    curl -fsSL "${ALIAS_SRC_URL}" | sh
 else
     echo "Error: curl is not installed. Unable to use Linux aliases"
     exit 1


### PR DESCRIPTION
This pull request makes a small but important fix to the `.devcontainer/postCreateScript.sh` script. The change ensures that the `ALIAS_SRC_URL` variable is properly quoted when used with `curl`, which helps prevent potential issues if the URL contains special characters or spaces.